### PR TITLE
fix: logger API changes from `vitest@0.18.0`

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,10 +38,10 @@
         "prettier": "^2.6.0",
         "typescript": "^4.6.2",
         "vite": "^2.9.14",
-        "vitest": "^0.17.1"
+        "vitest": "^0.18.0"
     },
     "peerDependencies": {
-        "vitest": ">=0.11.0"
+        "vitest": ">=0.18.0"
     },
     "keywords": [
         "vitest",

--- a/src/sonar-reporter.ts
+++ b/src/sonar-reporter.ts
@@ -36,7 +36,7 @@ export default class SonarReporter implements Reporter {
         }
 
         writeFileSync(reportFile, generateXml(files), 'utf-8');
-        this.ctx.log(`SonarQube report written to ${reportFile}`);
+        this.ctx.logger.log(`SonarQube report written to ${reportFile}`);
     }
 }
 

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -33,15 +33,15 @@ test('writes a report', () => {
             <failure message=\\"expected false to be true // Object.is equality\\">
               <![CDATA[AssertionError: expected false to be true // Object.is equality
           at <process-cwd>/test/fixtures/animals.test.ts:15:47
-          at <process-cwd>/node_modules/vitest/dist/chunk-runtime-chain.6d23d202.mjs:1938:36
-          at <process-cwd>/node_modules/vitest/dist/chunk-runtime-chain.6d23d202.mjs:1826:26
-          at runTest (<process-cwd>/node_modules/vitest/dist/vendor-entry.1ad8a08d.mjs:487:40)
-          at async runSuite (<process-cwd>/node_modules/vitest/dist/vendor-entry.1ad8a08d.mjs:570:13)
-          at async runSuite (<process-cwd>/node_modules/vitest/dist/vendor-entry.1ad8a08d.mjs:570:13)
-          at async runSuite (<process-cwd>/node_modules/vitest/dist/vendor-entry.1ad8a08d.mjs:570:13)
-          at async runFiles (<process-cwd>/node_modules/vitest/dist/vendor-entry.1ad8a08d.mjs:610:5)
-          at async startTests (<process-cwd>/node_modules/vitest/dist/vendor-entry.1ad8a08d.mjs:617:3)
-          at async <process-cwd>/node_modules/vitest/dist/vendor-entry.1ad8a08d.mjs:661:9]]>
+          at <process-cwd>/node_modules/vitest/dist/chunk-runtime-chain.eb764dff.mjs:1938:36
+          at <process-cwd>/node_modules/vitest/dist/chunk-runtime-chain.eb764dff.mjs:1826:26
+          at runTest (<process-cwd>/node_modules/vitest/dist/vendor-entry.78de67ab.mjs:487:40)
+          at async runSuite (<process-cwd>/node_modules/vitest/dist/vendor-entry.78de67ab.mjs:570:13)
+          at async runSuite (<process-cwd>/node_modules/vitest/dist/vendor-entry.78de67ab.mjs:570:13)
+          at async runSuite (<process-cwd>/node_modules/vitest/dist/vendor-entry.78de67ab.mjs:570:13)
+          at async runFiles (<process-cwd>/node_modules/vitest/dist/vendor-entry.78de67ab.mjs:610:5)
+          at async startTests (<process-cwd>/node_modules/vitest/dist/vendor-entry.78de67ab.mjs:617:3)
+          at async <process-cwd>/node_modules/vitest/dist/vendor-entry.78de67ab.mjs:661:9]]>
             </failure>
           </testCase>
           <testCase name=\\"animals - flying ones - bird can fly\\" duration=\\"123\\" />
@@ -54,30 +54,30 @@ test('writes a report', () => {
             <failure message=\\"expected 4 to deeply equal 8\\">
               <![CDATA[AssertionError: expected 4 to deeply equal 8
           at <process-cwd>/test/fixtures/math.test.ts:15:42
-          at <process-cwd>/node_modules/vitest/dist/chunk-runtime-chain.6d23d202.mjs:1938:36
-          at <process-cwd>/node_modules/vitest/dist/chunk-runtime-chain.6d23d202.mjs:1826:26
-          at runTest (<process-cwd>/node_modules/vitest/dist/vendor-entry.1ad8a08d.mjs:487:40)
-          at async runSuite (<process-cwd>/node_modules/vitest/dist/vendor-entry.1ad8a08d.mjs:570:13)
-          at async runSuite (<process-cwd>/node_modules/vitest/dist/vendor-entry.1ad8a08d.mjs:570:13)
-          at async runFiles (<process-cwd>/node_modules/vitest/dist/vendor-entry.1ad8a08d.mjs:610:5)
-          at async startTests (<process-cwd>/node_modules/vitest/dist/vendor-entry.1ad8a08d.mjs:617:3)
-          at async <process-cwd>/node_modules/vitest/dist/vendor-entry.1ad8a08d.mjs:661:9
-          at async withEnv (<process-cwd>/node_modules/vitest/dist/vendor-entry.1ad8a08d.mjs:171:5)]]>
+          at <process-cwd>/node_modules/vitest/dist/chunk-runtime-chain.eb764dff.mjs:1938:36
+          at <process-cwd>/node_modules/vitest/dist/chunk-runtime-chain.eb764dff.mjs:1826:26
+          at runTest (<process-cwd>/node_modules/vitest/dist/vendor-entry.78de67ab.mjs:487:40)
+          at async runSuite (<process-cwd>/node_modules/vitest/dist/vendor-entry.78de67ab.mjs:570:13)
+          at async runSuite (<process-cwd>/node_modules/vitest/dist/vendor-entry.78de67ab.mjs:570:13)
+          at async runFiles (<process-cwd>/node_modules/vitest/dist/vendor-entry.78de67ab.mjs:610:5)
+          at async startTests (<process-cwd>/node_modules/vitest/dist/vendor-entry.78de67ab.mjs:617:3)
+          at async <process-cwd>/node_modules/vitest/dist/vendor-entry.78de67ab.mjs:661:9
+          at async withEnv (<process-cwd>/node_modules/vitest/dist/vendor-entry.78de67ab.mjs:171:5)]]>
             </failure>
           </testCase>
           <testCase name=\\"math - complex calculation\\" duration=\\"123\\">
             <error message=\\"16.divideByTwo is not a function\\">
               <![CDATA[TypeError: 16.divideByTwo is not a function
           at <process-cwd>/test/fixtures/math.test.ts:18:38
-          at <process-cwd>/node_modules/vitest/dist/chunk-runtime-chain.6d23d202.mjs:1938:36
-          at <process-cwd>/node_modules/vitest/dist/chunk-runtime-chain.6d23d202.mjs:1826:26
-          at runTest (<process-cwd>/node_modules/vitest/dist/vendor-entry.1ad8a08d.mjs:487:40)
-          at async runSuite (<process-cwd>/node_modules/vitest/dist/vendor-entry.1ad8a08d.mjs:570:13)
-          at async runSuite (<process-cwd>/node_modules/vitest/dist/vendor-entry.1ad8a08d.mjs:570:13)
-          at async runFiles (<process-cwd>/node_modules/vitest/dist/vendor-entry.1ad8a08d.mjs:610:5)
-          at async startTests (<process-cwd>/node_modules/vitest/dist/vendor-entry.1ad8a08d.mjs:617:3)
-          at async <process-cwd>/node_modules/vitest/dist/vendor-entry.1ad8a08d.mjs:661:9
-          at async withEnv (<process-cwd>/node_modules/vitest/dist/vendor-entry.1ad8a08d.mjs:171:5)]]>
+          at <process-cwd>/node_modules/vitest/dist/chunk-runtime-chain.eb764dff.mjs:1938:36
+          at <process-cwd>/node_modules/vitest/dist/chunk-runtime-chain.eb764dff.mjs:1826:26
+          at runTest (<process-cwd>/node_modules/vitest/dist/vendor-entry.78de67ab.mjs:487:40)
+          at async runSuite (<process-cwd>/node_modules/vitest/dist/vendor-entry.78de67ab.mjs:570:13)
+          at async runSuite (<process-cwd>/node_modules/vitest/dist/vendor-entry.78de67ab.mjs:570:13)
+          at async runFiles (<process-cwd>/node_modules/vitest/dist/vendor-entry.78de67ab.mjs:610:5)
+          at async startTests (<process-cwd>/node_modules/vitest/dist/vendor-entry.78de67ab.mjs:617:3)
+          at async <process-cwd>/node_modules/vitest/dist/vendor-entry.78de67ab.mjs:661:9
+          at async withEnv (<process-cwd>/node_modules/vitest/dist/vendor-entry.78de67ab.mjs:171:5)]]>
             </error>
           </testCase>
           <testCase name=\\"math - random numbers are unstable\\">

--- a/yarn.lock
+++ b/yarn.lock
@@ -1534,10 +1534,10 @@ v8-compile-cache@^2.0.3:
   optionalDependencies:
     fsevents "~2.3.2"
 
-vitest@^0.17.1:
-  version "0.17.1"
-  resolved "https://registry.yarnpkg.com/vitest/-/vitest-0.17.1.tgz#0387535624538bfc1fe1a69fac617cca059428e2"
-  integrity sha512-d6NsFC6FPmZ5XdiSYfW5rwJ/b8060wqe2steNNlVbhO69HWma6CucIm5g7PXlCSkmKvrdEbUsZHPAarlH83VGw==
+vitest@^0.18.0:
+  version "0.18.0"
+  resolved "https://registry.yarnpkg.com/vitest/-/vitest-0.18.0.tgz#a9b59213ee6917e9da0797a2e1d7cb52b8f1b644"
+  integrity sha512-ryAtlh5Gvg3+aLNuOQ8YOHxgQCCu46jx40X5MBL0K0/ejB9i5zsr8fV8LTGXbXex80UMHlzceI9F+ouGaiR+mQ==
   dependencies:
     "@types/chai" "^4.3.1"
     "@types/chai-subset" "^1.3.3"


### PR DESCRIPTION
- Fixes #15 
- Ref. vitest-dev/vitest#1166 