### PR TITLE
fix: add better failover case for duration not being found

### DIFF
--- a/src/xml.ts
+++ b/src/xml.ts
@@ -115,7 +115,7 @@ function getAllTests(task: Task): Test[] {
 }
 
 function getDurationAttribute(test: Test): string {
-    const duration = test.result?.duration ?? test.file?.result?.duration;
+    const duration = test.result?.duration;
 
     if (typeof duration !== "number") {
         return ` duration="0"`;

--- a/src/xml.ts
+++ b/src/xml.ts
@@ -115,10 +115,10 @@ function getAllTests(task: Task): Test[] {
 }
 
 function getDurationAttribute(test: Test): string {
-    const duration = test.result?.duration;
+    const duration = test.result?.duration ?? test.file?.result?.duration;
 
-    if (typeof duration !== 'number') {
-        return '';
+    if (typeof duration !== "number") {
+        return ` duration="0"`;
     }
 
     return ` duration="${Math.round(duration)}"`;

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -26,7 +26,7 @@ test('writes a report', () => {
       "<testExecutions version=\\"1\\">
         <file path=\\"test/fixtures/animals.test.ts\\">
           <testCase name=\\"animals - dogs say woof\\" duration=\\"123\\" />
-          <testCase name=\\"animals - figure out what rabbits say\\">
+          <testCase name=\\"animals - figure out what rabbits say\\" duration=\\"123\\">
             <skipped message=\\"figure out what rabbits say\\" />
           </testCase>
           <testCase name=\\"animals - flying ones - cat can fly\\" duration=\\"123\\">
@@ -80,10 +80,10 @@ test('writes a report', () => {
           at async withEnv (<process-cwd>/node_modules/vitest/dist/vendor-entry.78de67ab.mjs:171:5)]]>
             </error>
           </testCase>
-          <testCase name=\\"math - random numbers are unstable\\">
+          <testCase name=\\"math - random numbers are unstable\\" duration=\\"123\\">
             <skipped message=\\"random numbers are unstable\\" />
           </testCase>
-          <testCase name=\\"math - learn square roots\\">
+          <testCase name=\\"math - learn square roots\\" duration=\\"123\\">
             <skipped message=\\"learn square roots\\" />
           </testCase>
           <testCase name=\\"math - divide - basic\\" duration=\\"123\\" />


### PR DESCRIPTION
This past week I have been on a tirade of skipping test cases, and I found that there was a case where if a suite is skipped the duration could be undefined, given there is either no value or no result for it. 

I have included the failover of reporting the file, which I am on the fence about, but more importantly, both paths through the method to retrieve the duration return a duration. 

Happy to discuss or update further!