### PR TITLE
feat: add support for rewriting `<file path="...">` attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,45 @@ test: {
 }
 ```
 
+#### `onWritePath`
+
+Rewrite `path` attribute of `<file>`. This can be useful when you need to change relative paths of the files.
+
+```ts
+test: {
+    reporters: [
+        ['vitest-sonar-reporter', {
+            onWritePath(path: string) {
+                // Prefix all paths with root directory
+                // e.g. '<file path="test/math.ts">' to '<file path="frontend/test/math.ts">'
+                return `frontend/${path}`;
+            }
+        }]
+    ],
+}
+```
+
+```diff
+<testExecutions version="1">
+-  <file path="test/math.ts">
++  <file path="frontend/test/math.ts">
+    <testCase name="multiply" duration="123" />
+  </file>
+</testExecutions>
+```
+
+#### `outputFile`
+
+Location for the report.
+
+```ts
+test: {
+    reporters: [
+        ['vitest-sonar-reporter', { outputFile: 'sonar-report.xml' }]
+    ],
+}
+```
+
 ## Code Coverage
 
 This reporter does not process code coverage - Vitest already supports that out-of-the-box!

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -68,6 +68,65 @@ test('writes a report', async () => {
     `);
 });
 
+test('file path can be rewritten using options.onWritePath ', async () => {
+    await runVitest({
+        reporterOptions: {
+            onWritePath(path: string) {
+                return `custom-prefix/${path}`;
+            },
+        },
+    });
+
+    const contents = readFileSync(outputFile, 'utf-8');
+    const stable = stabilizeReport(contents);
+
+    expect(stable).toMatchInlineSnapshot(`
+      "<testExecutions version="1">
+        <file path="custom-prefix/test/fixtures/animals.test.ts">
+          <testCase name="animals - dogs say woof" duration="123" />
+          <testCase name="animals - figure out what rabbits say" duration="123">
+            <skipped message="figure out what rabbits say" />
+          </testCase>
+          <testCase name="animals - flying ones - cat can fly" duration="123">
+            <failure message="expected false to be true // Object.is equality">
+              <![CDATA[AssertionError: expected false to be true // Object.is equality
+          at <process-cwd>/test/fixtures/animals.test.js
+          <removed-stacktrace>
+            </failure>
+          </testCase>
+          <testCase name="animals - flying ones - bird can fly" duration="123" />
+        </file>
+        <file path="custom-prefix/test/fixtures/math.test.ts">
+          <testCase name="math - sum" duration="123" />
+          <testCase name="math - multiply" duration="123" />
+          <testCase name="math - slow calculation" duration="123" />
+          <testCase name="math - tricky calculation of &quot;16 / 4&quot;" duration="123">
+            <failure message="expected 4 to deeply equal 8">
+              <![CDATA[AssertionError: expected 4 to deeply equal 8
+          at <process-cwd>/test/fixtures/math.test.js
+          <removed-stacktrace>
+            </failure>
+          </testCase>
+          <testCase name="math - complex calculation" duration="123">
+            <error message="16.divideByTwo is not a function">
+              <![CDATA[TypeError: 16.divideByTwo is not a function
+          at <process-cwd>/test/fixtures/math.test.js
+          <removed-stacktrace>
+            </error>
+          </testCase>
+          <testCase name="math - random numbers are unstable" duration="123">
+            <skipped message="random numbers are unstable" />
+          </testCase>
+          <testCase name="math - learn square roots" duration="123">
+            <skipped message="learn square roots" />
+          </testCase>
+          <testCase name="math - divide - basic" duration="123" />
+          <testCase name="math - divide - by zero" duration="123" />
+        </file>
+      </testExecutions>"
+    `);
+});
+
 test('report location is logged', async () => {
     const spy = vi.spyOn(console, 'log');
     await runVitest();


### PR DESCRIPTION
- Closes #153 
- Requires https://github.com/vitest-dev/vitest/pull/5111

Adds support for rewriting `path` attribute of `file`.

### Example:


Original report:

```xml
<testExecutions version="1">
  <file path="test/fixtures/animals.test.ts">
    <testCase name="animals - dogs say woof" duration="123" />
  </file>
</testExecutions>
```

```ts
import { defineConfig } from 'vitest/config';

export default defineConfig({
  test: {
    reporters: [
      ['vitest-sonar-reporter', {
        onWritePath(path: string) {
            console.log(path);
            //          ^^^^ "test/fixtures/animals.test.ts"

            return `frontend/${path}`;
        }
      }],
    ],
  },
});
```

```diff
<testExecutions version="1">
-  <file path="test/fixtures/animals.test.ts">
+  <file path="custom-prefix/test/fixtures/animals.test.ts">
    <testCase name="animals - dogs say woof" duration="123" />
  </file>
</testExecutions>
```

