### PR TITLE
feat: support custom options

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,13 +35,14 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
     test: {
-        reporters: 'vitest-sonar-reporter',
-        outputFile: 'sonar-report.xml',
+        reporters: [
+            ['vitest-sonar-reporter', { outputFile: 'sonar-report.xml' }],
+        ],
     },
 });
 ```
 
-If you have multiple outputFile's defined, add one for `vitest-sonar-reporter`:
+If you are using Vitest below version `^1.3.0` you can define file in `test.outputFile`:
 
 ```ts
 test: {
@@ -64,7 +65,7 @@ sonar.testExecutionReportPaths=sonar-report.xml
 
 ### Options
 
-You can pass additional options using `test.sonarReporterOptions` in `vite.config.ts`. Note that passing custom options to Vitest reporters is unconventional and may require you to use `@ts-ignore` when using TypeScript.
+You can pass additional options to reporter. Note that this requires `vitest@^1.3.0`.
 
 #### `silent`
 
@@ -72,8 +73,9 @@ Silence reporter's verbose logging.
 
 ```ts
 test: {
-    reporters: 'vitest-sonar-reporter',
-    sonarReporterOptions: { silent: true }
+    reporters: [
+        ['vitest-sonar-reporter', { silent: true }]
+    ],
 }
 ```
 

--- a/test/sonar-reporter.test.ts
+++ b/test/sonar-reporter.test.ts
@@ -7,7 +7,9 @@ test('resolves outputFile from string', () => {
 
     reporter.onInit(getConfig({ outputFile: 'test-report.xml' }));
 
-    expect(reporter.outputFile).toMatchInlineSnapshot('"test-report.xml"');
+    expect(reporter.options.outputFile).toMatchInlineSnapshot(
+        '"test-report.xml"',
+    );
 });
 
 test('resolves outputFile from object', () => {
@@ -21,7 +23,7 @@ test('resolves outputFile from object', () => {
         }),
     );
 
-    expect(reporter.outputFile).toMatchInlineSnapshot(
+    expect(reporter.options.outputFile).toMatchInlineSnapshot(
         '"test-report-from-object.xml"',
     );
 });
@@ -32,7 +34,7 @@ test('throws when outputFile is missing', () => {
     expect(() =>
         reporter.onInit(getConfig({ outputFile: undefined })),
     ).toThrowErrorMatchingInlineSnapshot(
-        `[Error: SonarReporter requires config.outputFile to be defined in vite config]`,
+        `[Error: SonarReporter requires outputFile to be defined in config]`,
     );
 });
 
@@ -45,14 +47,19 @@ test('throws when outputFile object is missing entry', () => {
         ),
     ).toThrowErrorMatchingInlineSnapshot(`
       [Error: Unable to resolve outputFile for vitest-sonar-reporter.
-Define outputFile as string or add entry for it:
-{
-  "test": {
-    "outputFile": {
-      "vitest-sonar-reporter": "sonar-report.xml"
-    }
-  }
-}]
+      Define outputFile in reporter options:
+      {
+        "test": {
+          "reporters": [
+            [
+              "vitest-sonar-reporter",
+              {
+                "outputFile": "sonar-report.xml"
+              }
+            ]
+          ]
+        }
+      }]
     `);
 });
 


### PR DESCRIPTION
Adds support for custom reporter options.

- github.com/vitest-dev/vitest/pull/5111

```ts
import { defineConfig } from "vitest/config";

export default defineConfig({
  test: {
    reporters: [
      "default",
      ["vitest-sonar-reporter", { outputFile: "sonar-report.xml", silent: true }],
      "junit",
    ],
  },
});
```