### PR TITLE
fix!: remove `sonarReporterOptions.silent` option

### DIFF
--- a/src/sonar-reporter.ts
+++ b/src/sonar-reporter.ts
@@ -30,12 +30,6 @@ export default class SonarReporter implements Reporter {
     onInit(ctx: Vitest) {
         this.ctx = ctx;
 
-        this.options.silent =
-            this.options.silent ||
-            // TODO: Remove in v2.0.0
-            // @ts-expect-error -- untyped
-            ctx.config.sonarReporterOptions?.silent === true;
-
         if (!this.ctx.config.outputFile && !this.options.outputFile) {
             throw new Error(
                 'SonarReporter requires outputFile to be defined in config',

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -141,15 +141,6 @@ test('report location is logged', async () => {
     );
 });
 
-test('logging can be silenced, legacy config', async () => {
-    const spy = vi.spyOn(console, 'log');
-    await runVitest({ config: { sonarReporterOptions: { silent: true } } });
-
-    expect(existsSync(outputFile)).toBe(true);
-    expect(spy).not.toHaveBeenCalled();
-    spy.mockRestore();
-});
-
 test('logging can be silenced via options', async () => {
     const spy = vi.spyOn(console, 'log');
     await runVitest({ reporterOptions: { silent: true } });


### PR DESCRIPTION
- Removes `sonarReporterOptions.silent` in favor of custom reporter options
- `sonarReporterOptions.silent` was added in https://github.com/AriPerkkio/vitest-sonar-reporter/pull/64
- Custom reporter options were added in https://github.com/AriPerkkio/vitest-sonar-reporter/pull/160

### Migration:

```diff
export default defineConfig({
  test: {
-    reporters: 'vitest-sonar-reporter',
-    sonarReporterOptions: { silent: true }
+    reporters: ['vitest-sonar-reporter', { silent: true }],
  },
});
```
