### PR TITLE
fix: add XML declaration to report

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 > [SonarQube](https://docs.sonarqube.org/) reporter for [Vitest](https://vitest.dev/)
 
-Generates [Generic Execution](https://docs.sonarqube.org/latest/analysis/generic-test/#header-2) reports from `vitest` tests for SonarQube to analyze.
+Generates [Generic Execution](https://docs.sonarsource.com/sonarqube-server/latest/analyzing-source-code/test-coverage/generic-test-data/#generic-test-execution) reports from `vitest` tests for SonarQube to analyze.
 
 ## Live examples
 
@@ -171,6 +171,7 @@ describe('animals', () => {
 ```
 
 ```xml
+<?xml version="1.0" encoding="UTF-8"?>
 <testExecutions version="1">
   <file path="test/animals.test.ts">
     <testCase name="animals - dogs say woof" duration="2" />

--- a/examples/example-basic/test/report.test.ts
+++ b/examples/example-basic/test/report.test.ts
@@ -12,7 +12,8 @@ test('report matches snapshot', () => {
     const report = stabilizeReport(output);
 
     expect(report).toMatchInlineSnapshot(`
-      "<testExecutions version="1">
+      "<?xml version="1.0" encoding="UTF-8"?>
+      <testExecutions version="1">
         <file path="test/math.test.ts">
           <testCase name="math - sum" duration="123" />
           <testCase name="math - multiply" duration="123" />

--- a/examples/example-workspace/report-test/report.test.ts
+++ b/examples/example-workspace/report-test/report.test.ts
@@ -17,7 +17,8 @@ test('report matches snapshot', () => {
     const report = stabilizeReport(output);
 
     expect(report).toMatchInlineSnapshot(`
-      "<testExecutions version="1">
+      "<?xml version="1.0" encoding="UTF-8"?>
+      <testExecutions version="1">
         <file path="packages/client/test/render-user.test.ts">
           <testCase name="renderUser - renders user" duration="123" />
         </file>

--- a/src/xml.ts
+++ b/src/xml.ts
@@ -8,6 +8,7 @@ const NEWLINE = '\n';
  * Generate XML. Reference:
  *
  * ```xml
+ * <?xml version="1.0" encoding="UTF-8"?>
  * <testExecutions version="1">
  *   <file path="testx/ClassOneTest.xoo">
  *     <testCase name="test1" duration="5"/>
@@ -26,6 +27,8 @@ const NEWLINE = '\n';
  */
 export function generateXml(files?: File[]) {
     return join(
+        '<?xml version="1.0" encoding="UTF-8"?>',
+        NEWLINE,
         '<testExecutions version="1">',
         NEWLINE,
         files?.map(generateFileElement).join(NEWLINE),

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -22,7 +22,8 @@ test('writes a report', async () => {
     const stable = stabilizeReport(contents);
 
     expect(stable).toMatchInlineSnapshot(`
-      "<testExecutions version="1">
+      "<?xml version="1.0" encoding="UTF-8"?>
+      <testExecutions version="1">
         <file path="test/fixtures/animals.test.ts">
           <testCase name="animals - dogs say woof" duration="123" />
           <testCase name="animals - figure out what rabbits say" duration="123">
@@ -81,7 +82,8 @@ test('file path can be rewritten using options.onWritePath ', async () => {
     const stable = stabilizeReport(contents);
 
     expect(stable).toMatchInlineSnapshot(`
-      "<testExecutions version="1">
+      "<?xml version="1.0" encoding="UTF-8"?>
+      <testExecutions version="1">
         <file path="custom-prefix/test/fixtures/animals.test.ts">
           <testCase name="animals - dogs say woof" duration="123" />
           <testCase name="animals - figure out what rabbits say" duration="123">


### PR DESCRIPTION
- Fixes https://github.com/AriPerkkio/vitest-sonar-reporter/issues/252

Adds missing `<?xml version="1.0" encoding="UTF-8"?>` in the beginning of the report. 